### PR TITLE
updating to node 18 + updating alpine to latest stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.15 as firefly-dataexchange-builder
+FROM node:18-alpine3.19 as firefly-dataexchange-builder
 ADD --chown=1001:0 . /firefly-dataexchange-https
 WORKDIR /firefly-dataexchange-https
 RUN mkdir /.npm \
@@ -17,7 +17,7 @@ RUN trivy fs --format spdx-json --output /sbom.spdx.json /SBOM
 RUN trivy sbom /sbom.spdx.json --severity UNKNOWN,HIGH,CRITICAL --exit-code 1
 
 
-FROM node:16-alpine3.15
+FROM node:18-alpine3.19
 WORKDIR /firefly-dataexchange-https
 COPY --from=firefly-dataexchange-builder /firefly-dataexchange-https/package.json /firefly-dataexchange-https
 COPY --from=firefly-dataexchange-builder /firefly-dataexchange-https/build /firefly-dataexchange-https/build


### PR DESCRIPTION
These items motivated sending this PR:
- nodejs@16 stopped receiving security updates in Sep 2023
- nodejs@16 vulnerability detected
- several vulnerabilities in older version of Alpine base images used in this repo

See this vuln scan using Trivy tool for how things looked before updates:
```
dx-https (alpine 3.15.6)

Total: 8 (UNKNOWN: 0, HIGH: 8, CRITICAL: 0)

┌──────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│   Library    │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                            │
├──────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ libcrypto1.1 │ CVE-2022-4450 │ HIGH     │ fixed  │ 1.1.1q-r0         │ 1.1.1t-r0     │ openssl: double free after calling PEM_read_bio_ex         │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                  │
│              ├───────────────┤          │        │                   │               ├────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0215 │          │        │                   │               │ openssl: use-after-free following BIO_new_NDEF             │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                  │
│              ├───────────────┤          │        │                   │               ├────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0286 │          │        │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                  │
│              ├───────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0464 │          │        │                   │ 1.1.1t-r2     │ openssl: Denial of service by excessive resource usage in  │
│              │               │          │        │                   │               │ verifying X509 policy...                                   │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                  │
├──────────────┼───────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│ libssl1.1    │ CVE-2022-4450 │          │        │                   │ 1.1.1t-r0     │ openssl: double free after calling PEM_read_bio_ex         │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                  │
│              ├───────────────┤          │        │                   │               ├────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0215 │          │        │                   │               │ openssl: use-after-free following BIO_new_NDEF             │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                  │
│              ├───────────────┤          │        │                   │               ├────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0286 │          │        │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                  │
│              ├───────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0464 │          │        │                   │ 1.1.1t-r2     │ openssl: Denial of service by excessive resource usage in  │
│              │               │          │        │                   │               │ verifying X509 policy...                                   │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                  │
└──────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
2024-04-01T16:44:27.466-0400    INFO    Table result includes only package filenames. Use '--format json' option to get the full path to the package file.

Node.js (node-pkg)

Total: 1 (UNKNOWN: 0, HIGH: 1, CRITICAL: 0)

┌─────────────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│               Library               │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                            │
├─────────────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ http-cache-semantics (package.json) │ CVE-2022-25881 │ HIGH     │ fixed  │ 4.1.0             │ 4.1.1         │ http-cache-semantics: Regular Expression Denial of Service │
│                                     │                │          │        │                   │               │ (ReDoS) vulnerability                                      │
│                                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-25881                 │
└─────────────────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```

All items above have been resolved in this PR.